### PR TITLE
Fix SerialWorker shutdown race

### DIFF
--- a/GUI_2.py
+++ b/GUI_2.py
@@ -42,6 +42,7 @@ class SerialWorker(QThread):
 
     def stop(s):
         s._running = False  # signal thread to exit; actual close in run()
+        s.wait()            # block until the thread has fully shut down
 
 class MainWindow(QMainWindow):
     def __init__(self):


### PR DESCRIPTION
## Summary
- block until SerialWorker thread exits

## Testing
- `python -m py_compile GUI_2.py`

------
https://chatgpt.com/codex/tasks/task_e_68815b5297ac8328a7aedcddf77237cf