### PR TITLE
Fix docstring spacing

### DIFF
--- a/GUI_2.py
+++ b/GUI_2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Robust PyQt5 TSL 1128 GUI with clean Connect/Disconnect
+Robust PyQt5 TSL 1128 GUI with clean Connect/Disconnect
 """
 import sys, serial, serial.tools.list_ports, re
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QLabel,


### PR DESCRIPTION
## Summary
- replace non-ASCII space in docstring of GUI_2.py

## Testing
- `python3 -m py_compile GUI_2.py`


------
https://chatgpt.com/codex/tasks/task_e_68815b509b8c832884ef5580f1870354