### PR TITLE
Add auto polling panel

### DIFF
--- a/GUI_2.py
+++ b/GUI_2.py
@@ -5,7 +5,7 @@ Robust PyQt5 TSL 1128 GUI with clean Connect/Disconnect
 import sys, serial, serial.tools.list_ports, re
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QLabel,
     QPushButton, QComboBox, QLineEdit, QTextEdit, QHBoxLayout,
-    QVBoxLayout, QTableWidget, QTableWidgetItem)
+    QVBoxLayout, QTableWidget, QTableWidgetItem, QDial)
 from PyQt5.QtCore import QThread, pyqtSignal, QTimer
 
 class SerialWorker(QThread):
@@ -34,11 +34,12 @@ class SerialWorker(QThread):
                 s.ser.close()
                 s.data_received.emit("🔌 Disconnected")
 
-    def write(s, cmd: str):
+    def write(s, cmd: str, echo=True):
         if s.ser and s.ser.is_open:
             for p in cmd.split(';'):
                 s.ser.write((p+"\r\n").encode())
-                s.data_received.emit(f">> {p}")
+                if echo:
+                    s.data_received.emit(f">> {p}")
 
     def stop(s):
         s._running = False  # signal thread to exit; actual close in run()
@@ -47,7 +48,10 @@ class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("TSL 1128 Interface"); self.resize(800,600)
-        w=QWidget(); self.setCentralWidget(w); l=QVBoxLayout(w)
+        w=QWidget(); self.setCentralWidget(w)
+        root=QHBoxLayout(w)
+        l=QVBoxLayout(); root.addLayout(l,1)
+        r=QVBoxLayout(); root.addLayout(r)
         # Port selector + Refresh
         h1=QHBoxLayout(); h1.addWidget(QLabel("Port:"))
         self.combo=QComboBox(); h1.addWidget(self.combo)
@@ -75,10 +79,25 @@ class MainWindow(QMainWindow):
         self.log=QTextEdit(readOnly=True); l.addWidget(self.log)
         self.tag_counts={}; self.table=QTableWidget(0,2)
         self.table.setHorizontalHeaderLabels(["Tag","Count"]); l.addWidget(self.table)
+        # Right side info containers
+        r.addWidget(QLabel("Version"))
+        self.version_display=QTextEdit(readOnly=True); r.addWidget(self.version_display)
+        r.addWidget(QLabel("Battery"))
+        self.battery_display=QTextEdit(readOnly=True); r.addWidget(self.battery_display)
+        r.addWidget(QLabel("Next poll"))
+        self.dial=QDial(); self.dial.setNotchesVisible(False)
+        r.addWidget(self.dial)
         # Auto‑poll
-        self.timer=QTimer(self); self.timer.timeout.connect(self.poll_status)
-        self.timer.start(10000)
+        self.poll_interval=10
+        self.countdown=self.poll_interval
+        self.dial.setRange(0,self.poll_interval)
+        self.dial.setValue(self.poll_interval)
+        self.timer=QTimer(self); self.timer.timeout.connect(self.update_countdown)
+        self.timer.start(1000)
         self.worker=None; self.refresh_ports()
+        self.silent_counter=0
+        self.current_cmd=None
+        self.version_info={}; self.battery_info={}
 
     def refresh_ports(self):
         ports=serial.tools.list_ports.comports(); self.combo.clear()
@@ -97,21 +116,35 @@ class MainWindow(QMainWindow):
         if self.worker: self.worker.stop(); self.worker=None
 
     def poll_status(self):
-        for cmd in (".vr", ".bl"): self.send_command(cmd)
+        for cmd in (".vr", ".bl"):
+            self.send_command(cmd, silent=True)
+        self.countdown=self.poll_interval
 
-    def send_command(self, cmd: str):
+    def send_command(self, cmd: str, silent=False):
         cmd=cmd.strip()
-        if not cmd: return
+        if not cmd:
+            return
         if not self.worker:
-            self.log.append("⚠️ Not connected"); return
-        self.log.append(f">> {cmd}"); self.worker.write(cmd)
+            if not silent:
+                self.log.append("⚠️ Not connected")
+            return
+        if not silent:
+            self.log.append(f">> {cmd}")
+        else:
+            self.silent_counter += len(cmd.split(';'))
+        self.worker.write(cmd, echo=not silent)
         self.input.clear()
 
     def process_data(self, text):
-        self.log.append(text)
+        silent = self.silent_counter > 0
+        if not silent:
+            self.log.append(text)
         if text.startswith("<< "):
             line = text[3:]
-            if ':' not in line and re.fullmatch(r'[0-9A-Fa-f]+', line.strip()):
+            self.parse_line(line)
+            if silent and (line == "OK:" or line.startswith("ER:")):
+                self.silent_counter -= 1
+            if not silent and ':' not in line and re.fullmatch(r'[0-9A-Fa-f]+', line.strip()):
                 t=line.strip()
                 self.tag_counts[t]=self.tag_counts.get(t,0)+1
                 self.update_table()
@@ -121,6 +154,36 @@ class MainWindow(QMainWindow):
         for r,(t,c) in enumerate(self.tag_counts.items()):
             self.table.setItem(r,0,QTableWidgetItem(t))
             self.table.setItem(r,1,QTableWidgetItem(str(c)))
+
+    def parse_line(self, line: str):
+        if line.startswith("CS:"):
+            self.current_cmd = line[4:].strip()
+        elif line == "OK:" or line.startswith("ER:"):
+            self.current_cmd = None
+        elif self.current_cmd == ".vr":
+            if ':' in line:
+                k,v = line.split(':',1)
+                self.version_info[k.strip()] = v.strip()
+                self.update_version_display()
+        elif self.current_cmd == ".bl":
+            if ':' in line:
+                k,v = line.split(':',1)
+                self.battery_info[k.strip()] = v.strip()
+                self.update_battery_display()
+
+    def update_version_display(self):
+        txt = '\n'.join(f"{k}: {v}" for k,v in self.version_info.items())
+        self.version_display.setPlainText(txt)
+
+    def update_battery_display(self):
+        txt = '\n'.join(f"{k}: {v}" for k,v in self.battery_info.items())
+        self.battery_display.setPlainText(txt)
+
+    def update_countdown(self):
+        self.dial.setValue(self.countdown)
+        self.countdown -= 1
+        if self.countdown < 0:
+            self.poll_status()
 
     def closeEvent(self, e):
         if self.worker: self.worker.stop()


### PR DESCRIPTION
## Summary
- add QDial and containers for version and battery info
- auto poll `.vr` and `.bl` every 10s
- hide auto poll responses from the console
- display progress wheel countdown

## Testing
- `python -m py_compile GUI_2.py`

------
https://chatgpt.com/codex/tasks/task_e_68815639912c8328ab3bad4bb0278919