### PR TITLE
Add basic README and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Python RFID GUI
+
+A PyQt5 interface for TSL 1128 RFID readers.
+
+## Prerequisites
+
+- Python 3
+- `pyserial`
+- `PyQt5`
+
+## Installation
+
+Install the dependencies with `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Launching
+
+Run the GUI application:
+
+```bash
+python GUI_2.py
+```
+
+Replace `python` with `python3` if needed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyserial
+PyQt5>=5


### PR DESCRIPTION
## Summary
- document prerequisites and usage in README
- specify dependencies in requirements.txt

## Testing
- `python3 -m py_compile GUI_2.py`


------
https://chatgpt.com/codex/tasks/task_e_6881a81103b883288aa18b5d162f112e