### PR TITLE
Refactor SerialWorker to use self

### DIFF
--- a/GUI_2.py
+++ b/GUI_2.py
@@ -55,22 +55,22 @@ BATTERY_LABELS = {
 class SerialWorker(QThread):
     data_received = pyqtSignal(str)
 
-    def __init__(s, port, baud=115200):
+    def __init__(self, port, baud=115200):
         super().__init__()
-        s.port = port
-        s.baud = baud
-        s._running = True
-        s.ser = None
+        self.port = port
+        self.baud = baud
+        self._running = True
+        self.ser = None
 
-    def run(s):
+    def run(self):
         try:
-            s.ser = serial.Serial(s.port, s.baud, timeout=1)
-            s.data_received.emit(f"✅ Connected to {s.port}")
+            self.ser = serial.Serial(self.port, self.baud, timeout=1)
+            self.data_received.emit(f"✅ Connected to {self.port}")
             buf = ""
-            while s._running:
+            while self._running:
                 try:
-                    n = s.ser.in_waiting or 1
-                    raw = s.ser.read(n).decode(errors="ignore")
+                    n = self.ser.in_waiting or 1
+                    raw = self.ser.read(n).decode(errors="ignore")
                 except (serial.SerialException, OSError):
                     break
                 if raw:
@@ -79,23 +79,23 @@ class SerialWorker(QThread):
                     buf = parts.pop()
                     for line in parts:
                         if line.strip():
-                            s.data_received.emit(f"<< {line}")
+                            self.data_received.emit(f"<< {line}")
         finally:
-            if s.ser and s.ser.is_open:
-                s.ser.close()
-                s.data_received.emit("🔌 Disconnected")
+            if self.ser and self.ser.is_open:
+                self.ser.close()
+                self.data_received.emit("🔌 Disconnected")
 
-    def write(s, cmd: str, echo=True):
-        if not (s.ser and s.ser.is_open):
+    def write(self, cmd: str, echo=True):
+        if not (self.ser and self.ser.is_open):
             return
         for p in cmd.split(";"):
-            s.ser.write((p + "\r\n").encode())
+            self.ser.write((p + "\r\n").encode())
             if echo:
-                s.data_received.emit(f">> {p}")
+                self.data_received.emit(f">> {p}")
 
-    def stop(s):
-        s._running = False  # signal thread to exit; actual close in run()
-        s.wait()            # block until the thread has fully shut down
+    def stop(self):
+        self._running = False  # signal thread to exit; actual close in run()
+        self.wait()            # block until the thread has fully shut down
 
 
 class MainWindow(QMainWindow):


### PR DESCRIPTION
## Summary
- use `self` instead of `s` in `SerialWorker` methods for clarity

## Testing
- `python -m py_compile GUI_2.py`


------
https://chatgpt.com/codex/tasks/task_e_6881a8152c888328bdaf2e9fdce75cf4