### PR TITLE
Fix union annotations for Python 3.9 compatibility

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -20,6 +20,7 @@ from PyQt5.QtWidgets import (
     QProgressBar,
 )
 from PyQt5.QtCore import QTimer
+from typing import Optional
 
 from serial_worker import SerialWorker
 from parsers import parse_line
@@ -154,7 +155,7 @@ class MainWindow(QMainWindow):
         self.refresh_ports()
 
         self.silent_queue: list[str] = []
-        self.current_cmd: str | None = None
+        self.current_cmd: Optional[str] = None
         self.current_silent = False
         self.version_info: dict[str, str] = {}
         self.battery_info: dict[str, str] = {}

--- a/parsers.py
+++ b/parsers.py
@@ -1,17 +1,17 @@
 """Utility functions for interpreting reader output."""
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 from constants import VERSION_LABELS, BATTERY_LABELS
 
 
 def parse_line(
     line: str,
-    current_cmd: str | None,
+    current_cmd: Optional[str],
     silent_queue: List[str],
     version_info: Dict[str, str],
     battery_info: Dict[str, str],
-) -> Tuple[str | None, bool, bool, bool]:
+) -> Tuple[Optional[str], bool, bool, bool]:
     """Parse a response line and update info dicts.
 
     Returns updated current_cmd, whether current_cmd is silent, and flags


### PR DESCRIPTION
## Summary
- update typing in `parsers` to avoid `|` union operator
- import `Optional` in GUI and update `current_cmd` typing

## Testing
- `python -m py_compile run.py gui.py parsers.py constants.py serial_worker.py GUI_2.py`

------
https://chatgpt.com/codex/tasks/task_e_6881b4cdf8f08328a33c6251eee6578f