### PR TITLE
Refactor parsers for extensible decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,21 @@ Replace `python` with `python3` if needed.
 ### Console output
 
 Commands sent to the reader appear once in the console prefixed with `>>`.
+
+### Response parsing
+
+The output from the reader follows a simple ``CS/OK/ER`` protocol.  Lines
+starting with ``CS:`` contain the echoed command, intermediate payload lines
+follow and the response terminates with either ``OK:`` or ``ER:``.  The
+``parsers`` module provides a :class:`ResponseParser` that collects these lines
+and delegates decoding of the payload to command specific decoders.
+
+Two commands are currently understood:
+
+- ``.vr`` – returns firmware and hardware version information as ``FIELD:VALUE``
+  pairs.  The fields are expanded to friendly names using ``VERSION_LABELS``.
+- ``.bl`` – reports battery statistics.  Fields such as ``BV`` (voltage) and
+  ``BP`` (charge percentage) are normalised for display.
+
+New commands can be supported by subclassing ``PayloadDecoder`` in
+``parsers.py`` and adding the instance to the ``DECODERS`` registry.


### PR DESCRIPTION
## Summary
- document response parsing in README
- refactor parser logic to use a new `PayloadDecoder` interface
- implement decoders for `.vr` and `.bl`
- delegate parsing through registry for future extension

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688456fd5e388328a31d58fe4f6db36c