### PR TITLE
Add decoder for .iv inventory command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ follow and the response terminates with either ``OK:`` or ``ER:``.  The
 ``parsers`` module provides a :class:`ResponseParser` that collects these lines
 and delegates decoding of the payload to command specific decoders.
 
-Two commands are currently understood:
+Three commands are currently understood:
 
 - ``.vr`` – returns firmware and hardware version information as ``FIELD:VALUE``
   pairs.  The fields are expanded to friendly names using ``VERSION_LABELS``.
 - ``.bl`` – reports battery statistics.  Fields such as ``BV`` (voltage) and
   ``BP`` (charge percentage) are normalised for display.
+- ``.iv`` – performs an inventory scan.  ``EP`` lines in the payload contain
+  EPC values which are tallied and displayed in the tag table.
 
 New commands can be supported by subclassing ``PayloadDecoder`` in
 ``parsers.py`` and adding the instance to the ``DECODERS`` registry.

--- a/gui.py
+++ b/gui.py
@@ -314,14 +314,15 @@ class MainWindow(QMainWindow):
             {
                 "version_info": self.version_info,
                 "battery_info": self.battery_info,
+                "tag_counts": self.tag_counts,
             },
         )
         self.update_version_display()
         self.update_battery_display()
 
         # Payload lines were already logged as they arrived while collecting the
-        # response, so avoid logging them again here. Tag counts have also been
-        # updated at that time.
+        # response, so avoid logging them again here. Tag counts are updated by
+        # the inventory decoder when the response completes.
 
         if not self.current_silent:
             if resp.ok:

--- a/parsers.py
+++ b/parsers.py
@@ -72,12 +72,28 @@ class BatteryDecoder(PayloadDecoder):
                 info[label] = v
 
 
+class InventoryDecoder(PayloadDecoder):
+    """Decoder for the ``.iv`` (inventory) command."""
+
+    command = ".iv"
+    target = "tag_counts"
+
+    def parse(self, lines: List[str], context: DecoderContext) -> None:
+        counts = context.setdefault(self.target, {})
+        for line in lines:
+            if line.startswith("EP:"):
+                tag = line[3:].strip()
+                if tag:
+                    counts[tag] = counts.get(tag, 0) + 1
+
+
 
 DECODERS: Dict[str, PayloadDecoder] = {
     d.command: d
     for d in (
         VersionDecoder(),
         BatteryDecoder(),
+        InventoryDecoder(),
     )
 }
 


### PR DESCRIPTION
## Summary
- decode `.iv` inventory responses
- wire inventory decoder to the GUI to populate tag counts
- document supported `.iv` command in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6884f814d72c8328838a518a4a2ab162