### PR TITLE
Limit graph history to 20 points

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -18,3 +18,6 @@ BATTERY_LABELS = {
     "BP": "Charge level",
     "CH": "Charging state",
 }
+
+# Maximum number of signal strength samples to retain per tag
+STRENGTH_HISTORY_LEN = 20

--- a/gui.py
+++ b/gui.py
@@ -26,6 +26,7 @@ from typing import Optional
 
 from serial_worker import SerialWorker
 from parsers import ResponseParser, parse_payload
+from constants import STRENGTH_HISTORY_LEN
 
 
 class MplCanvas(FigureCanvas):
@@ -111,7 +112,8 @@ class MainWindow(QMainWindow):
 
         self.tag_counts = {}
         self.tag_strengths: dict[str, list[float]] = {}
-        self.strength_history_len = 50
+        # Maximum number of signal strength samples to retain per tag
+        self.strength_history_len = STRENGTH_HISTORY_LEN
         self.pending_tag: Optional[str] = None
         self.selected_tag: Optional[str] = None
         self.table = QTableWidget(0, 2)

--- a/parsers.py
+++ b/parsers.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
-from constants import VERSION_LABELS, BATTERY_LABELS
+from constants import VERSION_LABELS, BATTERY_LABELS, STRENGTH_HISTORY_LEN
 
 
 DecoderContext = Dict[str, Dict[str, str]]
@@ -78,7 +78,8 @@ class InventoryDecoder(PayloadDecoder):
     command = ".iv"
     count_target = "tag_counts"
     strength_target = "tag_strengths"
-    history_len = 50
+    # Maximum number of signal strength samples to retain per tag
+    history_len = STRENGTH_HISTORY_LEN
 
     def parse(self, lines: List[str], context: DecoderContext) -> None:
         counts = context.setdefault(self.count_target, {})


### PR DESCRIPTION
## Summary
- keep only the latest 20 signal strength readings to reduce clutter
- consolidate history length into a single constant

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688590ce50388328b3047e81bd95ce0c