### PR TITLE
Add session toggle and tag filter controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ Three commands are currently understood:
 
 New commands can be supported by subclassing ``PayloadDecoder`` in
 ``parsers.py`` and adding the instance to the ``DECODERS`` registry.
+
+### Tag options
+
+The GUI provides a **Zero Persistence** toggle that switches the reader to
+Session&nbsp;0 for continuous tag strength updates.  In the default state the
+reader uses Session&nbsp;1, causing tags to fall silent briefly after each
+read.
+
+Select a tag in the table and click **Filter Tag** to have the reader observe
+only that tag.  Use **Clear Filter** to remove the filter.


### PR DESCRIPTION
## Summary
- allow switching between quiet tags (Session 1) and zero-persistence mode via toggle
- enable filtering to a selected tag with new Filter Tag and Clear Filter buttons

## Testing
- `python -m py_compile gui.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8466de508328a17ffc43b14e44f1