### PR TITLE
Track global min and max tag strengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ read.
 
 Select a tag in the table and click **Filter Tag** to have the reader observe
 only that tag.  Use **Clear Filter** to remove the filter.
+
+The tag table tracks the minimum and maximum signal strength seen for each
+tag. These values persist regardless of the limited history buffer and reset
+when **Clear Tags** is used.


### PR DESCRIPTION
## Summary
- Track global min and max signal strengths per tag in the inventory decoder
- Display per-tag min and max strengths in the GUI table and update them as readings arrive
- Document persistent strength extrema in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688ffbd499a48328ace9fca2ffd9fa12