### PR TITLE
Convert signal strength to percentage

### DIFF
--- a/parsers.py
+++ b/parsers.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from constants import VERSION_LABELS, BATTERY_LABELS, STRENGTH_HISTORY_LEN
+from utils import strength_to_percentage
 
 
 DecoderContext = Dict[str, Dict[str, str]]
@@ -108,6 +109,8 @@ class InventoryDecoder(PayloadDecoder):
                         strength = float(val_str)
                     except ValueError:
                         strength = None
+                if strength is not None:
+                    strength = strength_to_percentage(strength)
                 if last_tag:
                     hist = strengths.setdefault(last_tag, [])
                     if hist:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,16 @@
+"""Utility functions for signal strength conversion."""
+
+
+def strength_to_percentage(strength: float) -> int:
+    """Convert RSSI strength in dBm to a percentage.
+
+    Strength values at or below -90 map to 0 and values at or above -25 map to
+    100. Values between are scaled linearly.
+    """
+    if strength <= -90:
+        return 0
+    if strength >= -25:
+        return 100
+    # Linear interpolation over the range [-90, -25]
+    return int(round((strength + 90) * 100 / 65))
+


### PR DESCRIPTION
## Summary
- add helper to translate RSSI values to 0–100 percent
- display tag strength as percentage with min/max tracking

## Testing
- `python -m py_compile utils.py parsers.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6890003594748328a79a987d671d4e3e