### PR TITLE
Add tag search box replacing filter feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Session&nbsp;0 for continuous tag strength updates.  In the default state the
 reader uses Session&nbsp;1, causing tags to fall silent briefly after each
 read.
 
-Select a tag in the table and click **Filter Tag** to have the reader observe
-only that tag.  Use **Clear Filter** to remove the filter.
+Enter a tag ID in the **Search Tag** box to watch for a specific tag. The box
+is red until the reader observes the tag and turns green once it is detected.
 
 The tag table tracks the minimum and maximum signal strength seen for each
 tag. These values persist regardless of the limited history buffer and reset


### PR DESCRIPTION
## Summary
- replace filter/clear tag controls with a text box for searching for a specific tag
- show red background until searched tag is observed then turn it green
- update docs for new tag search behavior

## Testing
- `python -m py_compile gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68941f76e0208328952bbcde022c50f0