### PR TITLE
Handle unexpected RFID reader disconnects

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -344,6 +344,8 @@ class MainWindow(QMainWindow):
         """Stop the worker and reset the UI."""
         if self.worker:
             self.auto_reconnect = False
+            # Tell the reader we're disconnecting so it can sleep
+            self.send_command(".dc", silent=True)
             self.worker.stop()
             self.worker = None
         self.reconnecting = False
@@ -425,7 +427,12 @@ class MainWindow(QMainWindow):
 
     def on_disconnected(self):
         """Handle reader disconnection."""
-        self.log.append("🔌 Disconnected")
+        if self.auto_reconnect:
+            if not self.reconnecting:
+                self.log.append("🔌 Disconnected")
+                self.log.append("🔄 Reconnecting...")
+        else:
+            self.log.append("🔌 Disconnected")
         self.progress = 0
         self.version_bar.setValue(0)
         self.battery_bar.setValue(0)

--- a/gui.py
+++ b/gui.py
@@ -345,7 +345,7 @@ class MainWindow(QMainWindow):
         if self.worker:
             self.auto_reconnect = False
             # Tell the reader we're disconnecting so it can sleep
-            self.send_command(".dc", silent=True)
+            self.send_command(".sl", silent=True)
             self.worker.stop()
             self.worker = None
         self.reconnecting = False

--- a/gui.py
+++ b/gui.py
@@ -260,6 +260,8 @@ class MainWindow(QMainWindow):
         self.timer.start(100)
 
         self.worker = None
+        self.auto_reconnect = False
+        self.reconnecting = False
         self.scanning = False
         self.refresh_ports()
 
@@ -330,6 +332,7 @@ class MainWindow(QMainWindow):
         port = self.combo.currentData()
         if not port or self.worker:
             return
+        self.auto_reconnect = True
         self.worker = SerialWorker(port)
         self.worker.connected.connect(self.on_connected)
         self.worker.disconnected.connect(self.on_disconnected)
@@ -340,8 +343,10 @@ class MainWindow(QMainWindow):
     def disconnect_serial(self):
         """Stop the worker and reset the UI."""
         if self.worker:
+            self.auto_reconnect = False
             self.worker.stop()
             self.worker = None
+        self.reconnecting = False
         self.progress = 0
         self.version_bar.setValue(0)
         self.battery_bar.setValue(0)
@@ -407,14 +412,16 @@ class MainWindow(QMainWindow):
     def on_connected(self, port: str):
         """Handle reader connection."""
         self.log.append(f"✅ Connected to {port}")
-        self.tag_counts.clear()
-        self.tag_strengths.clear()
-        self.update_table()
-        self.update_strength_plot()
+        if not self.reconnecting:
+            self.tag_counts.clear()
+            self.tag_strengths.clear()
+            self.update_table()
+            self.update_strength_plot()
         self.send_inventory_setup()
         self.scanning = True
         if self.poll_enabled:
             self.poll_status()
+        self.reconnecting = False
 
     def on_disconnected(self):
         """Handle reader disconnection."""
@@ -424,6 +431,10 @@ class MainWindow(QMainWindow):
         self.battery_bar.setValue(0)
         self.scanning = False
         self.pending_tag = None
+        self.worker = None
+        if self.auto_reconnect:
+            self.reconnecting = True
+            QTimer.singleShot(1000, self.connect_serial)
 
     def on_command_sent(self, cmd: str):
         """Log sent commands that aren't silent."""

--- a/gui.py
+++ b/gui.py
@@ -431,7 +431,11 @@ class MainWindow(QMainWindow):
         self.battery_bar.setValue(0)
         self.scanning = False
         self.pending_tag = None
+        worker = self.worker
         self.worker = None
+        if worker:
+            worker.wait()
+            worker.deleteLater()
         if self.auto_reconnect:
             self.reconnecting = True
             QTimer.singleShot(1000, self.connect_serial)

--- a/serial_worker.py
+++ b/serial_worker.py
@@ -34,10 +34,13 @@ class SerialWorker(QThread):
                     break
                 if raw:
                     buf = self._emit_lines(buf, raw)
+        except (serial.SerialException, OSError):
+            # Opening the port failed or the connection dropped
+            pass
         finally:
             if self.ser and self.ser.is_open:
                 self.ser.close()
-                self.disconnected.emit()
+            self.disconnected.emit()
 
     def _emit_lines(self, buf: str, raw: str) -> str:
         """Emit complete lines from serial data and return remaining buffer.


### PR DESCRIPTION
## Summary
- Automatically reconnect to the reader when its serial connection drops unexpectedly
- Preserve tag data across automatic reconnects

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68952250f3208328bbcba7093feb624f