### PR TITLE
Improve serial reconnection for TSL 1128

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ python run.py
 
 Replace `python` with `python3` if needed.
 
+## Recovering after USB reconnects
+
+macOS can take a while to wake USB–serial adapters after they are unplugged.
+Use the included helper to toggle the control lines and nudge the reader without
+touching any cables:
+
+```bash
+python kick_port.py         # auto-detects the first USB serial port
+python kick_port.py /dev/tty.usbserial-FTXYZ  # or specify a port
+```
+
+The GUI now also asserts and drops DTR/RTS when connecting and disconnecting to
+speed up reconnection.
+
 ### Console output
 
 Commands sent to the reader appear once in the console prefixed with `>>`.

--- a/kick_port.py
+++ b/kick_port.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Toggle DTR/RTS on a USB serial adapter to wake the TSL 1128.
+
+This utility finds a likely serial port and briefly drops the control lines
+so the reader starts responding without needing to unplug it.
+"""
+
+import argparse
+import glob
+import time
+
+import serial
+
+
+def find_port() -> str | None:
+    """Return the first matching USB serial port or ``None``."""
+    ports = glob.glob("/dev/tty.usbserial*") + glob.glob("/dev/tty.usbmodem*")
+    return ports[0] if ports else None
+
+
+def kick(port: str | None) -> None:
+    port = port or find_port()
+    if not port:
+        print("No USB serial port found")
+        return
+    with serial.Serial(port, 115200, timeout=1) as ser:
+        ser.dtr = False
+        ser.rts = False
+        time.sleep(0.05)
+        ser.dtr = True
+        ser.rts = True
+    print(f"Kicked {port}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("port", nargs="?", help="Serial port (auto-detect if omitted)")
+    args = parser.parse_args()
+    kick(args.port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Assert and drop DTR/RTS in `SerialWorker` for faster connect/disconnect
- Add `kick_port.py` utility to toggle control lines and wake USB serial ports
- Document rapid reconnection workflow in README

## Testing
- `python -m py_compile serial_worker.py kick_port.py`
- `python kick_port.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68968c99948483289ce421728c86ec1e